### PR TITLE
#10 setSlide() w/o parameters goes to slide 0

### DIFF
--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -254,7 +254,7 @@ class VizzuPlayer extends HTMLElement {
     }
     this._update(this._state);
 
-    if (slide < 0) {
+    if (!slide || slide < 0) {
       slide = 0;
     } else if (slide >= this.length) {
       slide = this.length - 1;


### PR DESCRIPTION
`setSlide()` handles null/undefined by going to the first slide.

Fixes #10 