### PR TITLE
Added: custom Vizzu url support

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,4 +1,6 @@
-import VizzuPlayer from "https://cdn.jsdelivr.net/npm/vizzu-story@~0.1.0/dist/vizzu-story.min.js"; // eslint-disable-line no-unused-vars
+// import VizzuPlayer from "https://cdn.jsdelivr.net/npm/vizzu-story@latest/dist/vizzu-story.min.js";
+import VizzuPlayer from "../src/vizzu-player.js"; // eslint-disable-line no-unused-vars
+
 import data from "./data.js";
 import style from "./style.js";
 
@@ -17,7 +19,8 @@ const vizzuPlayerData = {
     // silde
     {
       config: {}, // Config.Chart
-      filter: () => true, // data.filter TODO: not declarative, cannot be serialized ??? string => Function
+      filter: () => true, // data.filter TODO: not declarative, cannot be
+      // serialized ??? string => Function
       style: {}, // Styles.Chart
       animOptions: {}, // Anim.Options
     },
@@ -124,10 +127,10 @@ const vpd = {
 };
 
 const vp = document.querySelector("vizzu-player");
-vp.slides = vpd; // init slides
-vp.vizzu.initializing.then((chart) =>
-  chart.on("plot-axis-label-draw", labelHandler)
-);
+vp.initializing.then((chart) => {
+  vp.slides = vpd; // init slides
+  chart.on("plot-axis-label-draw", labelHandler);
+});
 
 /*
 TODO:

--- a/src/__tests__/vizzu-player._convertSlides.test.js
+++ b/src/__tests__/vizzu-player._convertSlides.test.js
@@ -1,11 +1,13 @@
 import VizzuPlayer from "../vizzu-player.js";
 
+import Vizzu from "../__mocks__/vizzu.js";
 import { slides } from "./assets/slides.js";
 
 describe("VizzuPlayer class", () => {
   describe("_convertSlides method", () => {
     it("should throw error if slides do not contain slides", () => {
       const vizzuPlayer = new VizzuPlayer();
+      vizzuPlayer.vizzu = new Vizzu();
       const passedSlides = {};
       return expect(
         vizzuPlayer._convertSlides(passedSlides)
@@ -16,6 +18,7 @@ describe("VizzuPlayer class", () => {
       "should return valid slides if %s",
       (name, passedSlides, expectedSlides) => {
         const vizzuPlayer = new VizzuPlayer();
+        vizzuPlayer.vizzu = new Vizzu();
         return vizzuPlayer
           ._convertSlides(passedSlides)
           .then((convertedSlides) => {

--- a/src/__tests__/vizzu-player._setSlides.test.js
+++ b/src/__tests__/vizzu-player._setSlides.test.js
@@ -1,11 +1,13 @@
 import VizzuPlayer from "../vizzu-player.js";
 
+import Vizzu from "../__mocks__/vizzu.js";
 import { slides } from "./assets/slides.js";
 
 describe("VizzuPlayer class", () => {
   describe("_setSlides method", () => {
     it("should throw error if slides do not contain slides", () => {
       const vizzuPlayer = new VizzuPlayer();
+      vizzuPlayer.vizzu = new Vizzu();
       const passedSlides = {};
       return expect(vizzuPlayer._setSlides(passedSlides)).rejects.toMatchObject(
         TypeError("slides.slides is not iterable")
@@ -16,6 +18,7 @@ describe("VizzuPlayer class", () => {
       "should return valid slides if %s",
       (name, passedSlides, expectedSlides) => {
         const vizzuPlayer = new VizzuPlayer();
+        vizzuPlayer.vizzu = new Vizzu();
         return vizzuPlayer._setSlides(passedSlides).then(() => {
           expect(vizzuPlayer.slides).toStrictEqual(expectedSlides);
         });

--- a/src/__tests__/vizzu-player.setSlide.test.js
+++ b/src/__tests__/vizzu-player.setSlide.test.js
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 
 import VizzuPlayer from "../vizzu-player.js";
 
+import VizzuMock from "../__mocks__/vizzu.js";
 import { story } from "./assets/slides.js";
 
 describe("VizzuPlayer class", () => {
@@ -30,6 +31,7 @@ describe("VizzuPlayer class", () => {
 
     it("should call _update if slides are not empty and acquire lock", () => {
       const vizzuPlayer = new VizzuPlayer();
+      vizzuPlayer.vizzu = new VizzuMock();
       vizzuPlayer._slides = story[2];
       vizzuPlayer._locked = false;
       const _updateMock = jest.spyOn(vizzuPlayer, "_update");

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -1,7 +1,5 @@
 import VizzuController from "./vizzu-controller.js";
 
-import Vizzu from "https://cdn.jsdelivr.net/npm/vizzu@~0.5.0/dist/vizzu.min.js";
-
 const LOG_PREFIX = [
   "%cVIZZU%cPLAYER",
   "background: #e2ae30; color: #3a60bf; font-weight: bold",
@@ -15,7 +13,18 @@ class VizzuPlayer extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this.shadowRoot.innerHTML = this._render();
 
-    this._initVizzu();
+    this._resolveVizzu = null;
+    this.initializing = new Promise((resolve) => {
+      this._resolveVizzu = resolve;
+    }).then(() => this.vizzu.initializing);
+  }
+
+  async connectedCallback() {
+    await this._initVizzu();
+    if (!this.hasAttribute("tabindex")) {
+      this.setAttribute("tabindex", 0);
+      this.tabIndex = 0;
+    }
   }
 
   get debug() {
@@ -31,8 +40,20 @@ class VizzuPlayer extends HTMLElement {
     }
   }
 
-  _initVizzu() {
-    this.vizzu = new Vizzu(this.vizzuCanvas);
+  get vizzuUrl() {
+    return (
+      this.getAttribute("vizzu-url") ||
+      "https://cdn.jsdelivr.net/npm/vizzu@latest/dist/vizzu.min.js"
+    );
+  }
+
+  async _initVizzu() {
+    if (!this.vizzu) {
+      // load and init vizzu
+      const Vizzu = window.Vizzu || (await import(this.vizzuUrl)).default;
+      this._resolveVizzu(Vizzu);
+      this.vizzu = new Vizzu(this.vizzuCanvas);
+    }
   }
 
   _slideToAnimparams(slide) {

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -474,4 +474,3 @@ customElements.define("vizzu-player", VizzuPlayer);
 
 export default VizzuPlayer;
 export { VizzuController };
-export { Vizzu };

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -27,13 +27,6 @@ class VizzuPlayer extends HTMLElement {
     }
   }
 
-  connectedCallback() {
-    if (!this.hasAttribute("tabindex")) {
-      this.setAttribute("tabindex", 0);
-      this.tabIndex = 0;
-    }
-  }
-
   get debug() {
     try {
       const debugCookie = document.cookie


### PR DESCRIPTION
- url for vizzu library can be set via `vizzu-url` HTML attribute
- if Vizzu is already loaded, that instance will be used
- *[API CHANGE]* don't use `vizzuPlayer.vizzu.initialized` directly, use `vizzuPlayer.initialized` instead (`vizzu` property might not be available, due to async loading)

Implements #15 